### PR TITLE
Implement OAuth login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 
 | Topic                          | Look in…                                |
 | ------------------------------ | --------------------------------------- |
-| Streamlit page flow            | `src/label_app/ui/pages/`               |
+| Streamlit page flow            | `src/label_app/ui/page/`                |
 | Task‑type renderers            | `src/label_app/ui/components/*_view.py` |
 | Domain services (Git, auth, …) | `src/label_app/services/`               |
 | Data models & item schemas     | `src/label_app/data/models.py`          |
@@ -35,3 +35,4 @@
 | Added project skeleton under `src/label_app/` with Streamlit stubs and config files. | Establish deployable base for future feature work. |
 | Documented preference for Material icons and replaced emoji page icon. | Align UI with design guidelines. |
 | Added login modal, key-based auth, and logout button. | Implement basic authentication flow. |
+| Implemented OAuth login for GitHub/Google; updated docs. | Enable real third-party login. |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -126,11 +126,13 @@ def render_item(item: Item, project: Project) -> ItemAnnotation:
 
 ```python
 class AuthService:
+    def get_authorize_url(provider: Literal["github", "google"]) -> str: ...
     def login_with_oauth(provider: Literal["github", "google"], code: str) -> User: ...
     def login_with_key(key: str) -> User: ...  # constant‑time compare
 ```
 
 * **Security note** – keys are pre‑hashed with SHA‑256 and stored in `.streamlit/secrets.toml` as `KEY_SHA256 -> user_login` entries. No plain keys on disk.
+* OAuth client IDs and secrets are also stored under `[oauth]` sections in `secrets.toml`.
 * The login screen is presented in a modal via `require_login()`; all pages call this helper so navigation is blocked until authentication succeeds. The access-key form hints to contact the admin using `Settings.admin_email`.
 
 ### 5.2 `services.projects`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,6 @@ dependencies = [
     "pydantic[email]",
     "streamlit-cookies-controller",
     "PyYAML",
-    "PyJWT"
+    "PyJWT",
+    "Authlib"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pydantic[email]
 streamlit-cookies-controller
 PyYAML
 PyJWT
+Authlib

--- a/src/label_app/services/auth.py
+++ b/src/label_app/services/auth.py
@@ -5,6 +5,8 @@ import hashlib
 import hmac
 from typing import Literal, Optional
 
+from authlib.integrations.requests_client import OAuth2Session
+
 import jwt
 
 from label_app.data.models import User
@@ -31,10 +33,42 @@ def _safe_equals(a: str, b: str) -> bool:  # pragma: no cover  (wrapper)
 
 class AuthService:
 
-    def __init__(self, public_keys: dict[str, str], auth_secret: str | None = None) -> None:
+    def __init__(self, public_keys: dict[str, str], auth_secret: str | None = None, *, oauth_cfg: dict[str, dict[str, str]] | None = None) -> None:
         # normalise the digests to lowercase for reliable comparison
         self._public_keys = {login: digest.lower() for login, digest in public_keys.items()}
         self._auth_secret = auth_secret
+        self._oauth_cfg = oauth_cfg or {}
+
+    # ------------------------------------------------------------------
+    # OAuth helpers
+    # ------------------------------------------------------------------
+
+    def _session(self, provider: Literal["github", "google"]) -> OAuth2Session:
+        cfg = self._oauth_cfg.get(provider)
+        if not cfg:
+            raise ValueError(f"No OAuth config for {provider}")
+
+        return OAuth2Session(
+            client_id=cfg["client_id"],
+            client_secret=cfg["client_secret"],
+            redirect_uri=cfg["redirect_uri"],
+        )
+
+    def get_authorize_url(self, provider: Literal["github", "google"]) -> str:
+        session = self._session(provider)
+        if provider == "github":
+            url, _ = session.create_authorization_url(
+                "https://github.com/login/oauth/authorize",
+                scope="read:user",
+            )
+        else:
+            url, _ = session.create_authorization_url(
+                "https://accounts.google.com/o/oauth2/v2/auth",
+                scope="openid email profile",
+                access_type="online",
+                prompt="select_account",
+            )
+        return url
 
     def login_with_key(self, key: str) -> Optional[User]:
         """Return a :class:`~label_app.data.models.User` if *key* matches."""
@@ -44,12 +78,33 @@ class AuthService:
                 return User(login=login)
         return None
 
-    def login_with_oauth(self, provider: Literal["github", "google"], code: str | None = None) -> User:
-        """Dummy OAuth implementation (to be replaced later).
+    def login_with_oauth(self, provider: Literal["github", "google"], code: str) -> User:
+        """Exchange *code* for an access token and return the provider profile."""
 
-        """
-        # TODO: exchange *code* for an access token & fetch profile from provider
-        return User(login=f"{provider}_user")
+        session = self._session(provider)
+
+        if provider == "github":
+            token = session.fetch_token(
+                "https://github.com/login/oauth/access_token",
+                code=code,
+                headers={"Accept": "application/json"},
+            )
+            resp = session.get("https://api.github.com/user", token=token)
+            resp.raise_for_status()
+            login = resp.json()["login"]
+        else:
+            token = session.fetch_token(
+                "https://oauth2.googleapis.com/token",
+                code=code,
+            )
+            resp = session.get(
+                "https://openidconnect.googleapis.com/v1/userinfo",
+                token=token,
+            )
+            resp.raise_for_status()
+            login = resp.json()["email"]
+
+        return User(login=login)
 
     def issue_token(self, user: User, days_valid: int = DEFAULT_EXPIRY_DAYS) -> str:
         expires_at = dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=days_valid)

--- a/src/label_app/ui/components/auth.py
+++ b/src/label_app/ui/components/auth.py
@@ -11,7 +11,8 @@ from label_app.ui.components.cookies import get_cookie, put_cookie, remove_cooki
 def get_auth_service() -> AuthService:
     return AuthService(
         public_keys=get_settings().public_keys,
-        auth_secret=st.secrets.get("AUTH_SECRET")
+        auth_secret=st.secrets.get("AUTH_SECRET"),
+        oauth_cfg=st.secrets.get("oauth", {}),
     )
 
 

--- a/src/label_app/ui/page/01_login.py
+++ b/src/label_app/ui/page/01_login.py
@@ -6,22 +6,34 @@ from label_app.ui.components.auth import get_auth_service, set_login
 
 auth = get_auth_service()
 
-with st.form(key="login_modal", clear_on_submit=False, width="stretch"):
-    st.header("Login")
-    st.caption("Use one of the methods below to access the app.")
+params = st.query_params
+provider = params.get("provider")
+code = params.get("code")
+if provider and code:
+    set_login(auth.login_with_oauth(provider, code))
+    st.query_params.clear()
+    st.rerun()
 
-    col1, col2 = st.columns(2)
-    with col1:
-        if st.form_submit_button("Login with GitHub", use_container_width=True):
-            set_login(auth.login_with_oauth("github"))
-            st.rerun()
-    with col2:
-        if st.form_submit_button("Login with Google", use_container_width=True):
-            set_login(auth.login_with_oauth("google"))
-            st.rerun()
+st.header("Login")
+st.caption("Use one of the methods below to access the app.")
 
-    st.markdown("---")
+col1, col2 = st.columns(2)
+with col1:
+    st.link_button(
+        "Login with GitHub",
+        auth.get_authorize_url("github"),
+        use_container_width=True,
+    )
+with col2:
+    st.link_button(
+        "Login with Google",
+        auth.get_authorize_url("google"),
+        use_container_width=True,
+    )
 
+st.markdown("---")
+
+with st.form(key="key_login", clear_on_submit=False):
     access_key = st.text_input(
         "Access key",
         type="password",


### PR DESCRIPTION
## Summary
- allow OAuth config via secrets in `get_auth_service`
- implement OAuth2 flows for GitHub and Google
- expose authorization URL helper
- handle OAuth callback in login page and switch login buttons to links
- record changes in design/agent docs
- add `Authlib` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf0d90798833194ba5019e5d9131b