### PR TITLE
Implement project selection page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,4 @@
 | Added login modal, key-based auth, and logout button. | Implement basic authentication flow. |
 | Implemented OAuth login for GitHub/Google; updated docs. | Enable real third-party login. |
 | Documented `secrets.toml` layout in README. | Clarify required config. |
+| Implemented project selection with repo cloning & YAML meta. | Enables annotators to choose versioned projects from settings. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,6 @@ dependencies = [
     "streamlit-cookies-controller",
     "PyYAML",
     "PyJWT",
-    "Authlib"
+    "Authlib",
+    "GitPython>=3.1"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,6 @@ dependencies = [
     "PyYAML",
     "PyJWT",
     "Authlib",
-    "GitPython>=3.1"
+    "GitPython>=3.1",
+    "platformdirs"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ streamlit-cookies-controller
 PyYAML
 PyJWT
 Authlib
+GitPython>=3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML
 PyJWT
 Authlib
 GitPython>=3.1
+platformdirs

--- a/src/label_app/app_settings.yaml
+++ b/src/label_app/app_settings.yaml
@@ -5,3 +5,4 @@ public_keys:
 
 projects:
   test: https://github.com/viktor-shcherb/test-dataset/tree/master/test_project
+  also_test: https://github.com/viktor-shcherb/test-dataset/tree/master/another_project

--- a/src/label_app/data/models.py
+++ b/src/label_app/data/models.py
@@ -1,19 +1,79 @@
-from pathlib import Path
+from __future__ import annotations
 
-from pydantic import BaseModel
+from pathlib import Path
+from typing import Annotated, Dict, List, Literal, Union
+
+from pydantic import BaseModel, Field
 
 
 class User(BaseModel):
     login: str
 
 
-class Project(BaseModel):
-    """Metadata for a single project version."""
+class LabelGroup(BaseModel):
+    single_choice: bool = False
+    labels: List[str]
 
-    slug: str
-    version: str
+
+class ProjectBase(BaseModel):
+    # ── from project.yaml ───────────────────
     name: str
     description: str | None = None
+    task_type: str                           # discriminator
+
+    # ── derived from repository ────────────
+    version: str
+    slug: str
     repo_url: str
     repo_path: Path
     project_root: Path
+
+    model_config = dict(extra="forbid")      # help catch typos
+
+
+# Chat ────────────────────────────────────
+
+class ChatOptions(BaseModel):
+    annotate_roles: List[str] = Field(default_factory=list, description="Roles to tag")
+
+
+class ChatProject(ProjectBase):
+    task_type: Literal["chat"] = "chat"
+    chat_options: ChatOptions = Field(default_factory=ChatOptions)
+    label_groups: Dict[str, LabelGroup]
+
+
+# ──────────────────────────────────────────
+
+# Polymorphic union – Pydantic picks the right subclass by task_type
+Project = Annotated[
+    Union[ChatProject],                     # , ImageProject, …
+    Field(discriminator="task_type"),
+]
+
+
+# ────────────────────────────────────────────────────────────────
+# Factory helper for callers that already have repo metadata
+# ────────────────────────────────────────────────────────────────
+def make_project(
+    yaml_data: dict,
+    *,
+    slug: str,
+    version: str,
+    repo_url: str,
+    repo_path: Path,
+    project_root: Path,
+) -> Project:
+    """
+    Combine YAML + repo context and return the *right* Project subclass.
+    Raises `pydantic.ValidationError` if the YAML doesn't match a model.
+    """
+    merged = {
+        **yaml_data,
+        "slug": slug,
+        "version": version,
+        "repo_url": repo_url,
+        "repo_path": repo_path,
+        "project_root": project_root,
+    }
+    return Project.model_validate(merged)   # discriminator magic

--- a/src/label_app/data/models.py
+++ b/src/label_app/data/models.py
@@ -1,5 +1,19 @@
+from pathlib import Path
+
 from pydantic import BaseModel
 
 
 class User(BaseModel):
     login: str
+
+
+class Project(BaseModel):
+    """Metadata for a single project version."""
+
+    slug: str
+    version: str
+    name: str
+    description: str | None = None
+    repo_url: str
+    repo_path: Path
+    project_root: Path

--- a/src/label_app/services/git_client.py
+++ b/src/label_app/services/git_client.py
@@ -1,1 +1,30 @@
-# Placeholder for Git operations
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+import streamlit as st
+from git import Repo
+
+CACHE_DIR = Path.home() / ".cache" / "label_app" / "repos"
+
+
+def _repo_dest(url: str) -> Path:
+    """Return the filesystem path for the given Git *url*."""
+    parts = urlparse(url)
+    owner, repo = Path(parts.path).parts[1:3]
+    dest = CACHE_DIR / owner / repo.replace('.git', '')
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+@st.cache_resource()
+def clone_or_pull(url: str) -> Path:
+    """Clone *url* into the cache or pull the latest changes."""
+    dest = _repo_dest(url)
+    if dest.exists() and (dest / ".git").exists():
+        repo = Repo(dest)
+        repo.remotes.origin.pull()
+    else:
+        Repo.clone_from(url, dest)
+    return dest

--- a/src/label_app/services/projects.py
+++ b/src/label_app/services/projects.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+import streamlit as st
+
+from label_app.config.settings import AppSettings, get_settings
+from label_app.data.models import Project
+from label_app.services.git_client import clone_or_pull
+
+
+@st.cache_data()
+def parse_repo_url(raw_url: str) -> tuple[str, str]:
+    """Return ``(repo_url, subdir)`` for a GitHub tree URL."""
+    if "/tree/" in raw_url:
+        repo_part, sub_path = raw_url.split("/tree/", 1)
+        repo_url = repo_part + ".git" if not repo_part.endswith(".git") else repo_part
+        parts = sub_path.split("/", 1)
+        subdir = parts[1] if len(parts) > 1 else ""
+    else:
+        repo_url = raw_url if raw_url.endswith(".git") else raw_url + ".git"
+        subdir = ""
+    return repo_url, subdir
+
+
+@st.cache_data()
+def discover_projects(settings: AppSettings | None = None) -> dict[str, list[Project]]:
+    """Clone repos listed in *settings* and return discovered projects."""
+    settings = settings or get_settings()
+    result: dict[str, list[Project]] = {}
+
+    for slug, raw_url in settings.projects.items():
+        repo_url, subdir = parse_repo_url(raw_url)
+        repo_path = clone_or_pull(repo_url)
+        base = repo_path / subdir if subdir else repo_path
+        versions: list[Project] = []
+        for version_dir in sorted(base.iterdir()):
+            yaml_path = version_dir / "project.yaml"
+            if not yaml_path.exists():
+                continue
+            with yaml_path.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            versions.append(
+                Project(
+                    slug=slug,
+                    version=version_dir.name,
+                    name=data.get("name", slug),
+                    description=data.get("description"),
+                    repo_url=repo_url,
+                    repo_path=repo_path,
+                    project_root=version_dir,
+                )
+            )
+        if versions:
+            result[slug] = versions
+    return result

--- a/src/label_app/services/projects.py
+++ b/src/label_app/services/projects.py
@@ -1,57 +1,85 @@
 from __future__ import annotations
 
-from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 import streamlit as st
 
-from label_app.config.settings import AppSettings, get_settings
-from label_app.data.models import Project
+from label_app.config.settings import get_settings
+from label_app.data.models import Project, make_project
 from label_app.services.git_client import clone_or_pull
 
 
-@st.cache_data()
-def parse_repo_url(raw_url: str) -> tuple[str, str]:
-    """Return ``(repo_url, subdir)`` for a GitHub tree URL."""
-    if "/tree/" in raw_url:
-        repo_part, sub_path = raw_url.split("/tree/", 1)
-        repo_url = repo_part + ".git" if not repo_part.endswith(".git") else repo_part
-        parts = sub_path.split("/", 1)
-        subdir = parts[1] if len(parts) > 1 else ""
-    else:
-        repo_url = raw_url if raw_url.endswith(".git") else raw_url + ".git"
-        subdir = ""
-    return repo_url, subdir
+@st.cache_data(show_spinner=False)
+def parse_repo_url(raw_url: str) -> tuple[str, str | None, str]:
+    """
+    Canonicalise a GitHub URL and return **(repo_url, branch, subdir)**.
+
+    ▸ *repo_url* → always https://github.com/<owner>/<repo>.git
+    ▸ *branch*   → branch name or None (means: default branch)
+    ▸ *subdir*   → path inside the repo, may be ''
+    """
+    parsed = urlparse(raw_url.strip())
+    if parsed.netloc.lower() != "github.com":
+        st.error(f"Failed to parse project source: {raw_url}. Only GitHub URLs are supported.")
+        raise ValueError("Non-GitHub URL")
+
+    path = parsed.path.rstrip("/")
+    if "/tree/" in path:
+        repo_part, tree_part = path.split("/tree/", 1)
+        owner_repo = repo_part.lstrip("/")
+        branch, *rest = tree_part.split("/", 1)
+        subdir = rest[0] if rest else ""
+    else:                           # plain repo URL → no branch, no sub-path
+        owner_repo = path.lstrip("/")
+        branch, subdir = None, ""
+
+    repo_url = f"https://github.com/{owner_repo}"
+    if not repo_url.endswith(".git"):
+        repo_url += ".git"
+
+    return repo_url, branch, subdir
 
 
-@st.cache_data()
-def discover_projects(settings: AppSettings | None = None) -> dict[str, list[Project]]:
+@st.cache_data(show_spinner=False)
+def discover_projects() -> dict[str, list[Project]]:
     """Clone repos listed in *settings* and return discovered projects."""
-    settings = settings or get_settings()
-    result: dict[str, list[Project]] = {}
+    settings = get_settings()
+    discovered: dict[str, list[Project]] = {}
 
     for slug, raw_url in settings.projects.items():
-        repo_url, subdir = parse_repo_url(raw_url)
-        repo_path = clone_or_pull(repo_url)
-        base = repo_path / subdir if subdir else repo_path
-        versions: list[Project] = []
-        for version_dir in sorted(base.iterdir()):
-            yaml_path = version_dir / "project.yaml"
-            if not yaml_path.exists():
-                continue
-            with yaml_path.open("r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-            versions.append(
-                Project(
-                    slug=slug,
-                    version=version_dir.name,
-                    name=data.get("name", slug),
-                    description=data.get("description"),
-                    repo_url=repo_url,
-                    repo_path=repo_path,
-                    project_root=version_dir,
+        try:
+            repo_url, branch, subdir = parse_repo_url(raw_url)
+            repo_path = clone_or_pull(repo_url, branch)
+            base = repo_path / subdir if subdir else repo_path
+            if not base.exists():
+                st.error(
+                    f"Path '{subdir or '.'}' not found in "
+                    f"{repo_url}@{branch or 'default'}"
                 )
-            )
-        if versions:
-            result[slug] = versions
-    return result
+                continue
+
+            versions: list[Project] = []
+            for version_dir in sorted(p for p in base.iterdir() if p.is_dir()):
+                yaml_path = version_dir / "project.yaml"
+                if not yaml_path.is_file():
+                    continue
+                with yaml_path.open(encoding="utf-8") as f:
+                    data = yaml.safe_load(f) or {}
+                versions.append(
+                    make_project(
+                        yaml_data=data,
+                        slug=slug,
+                        version=version_dir.name,
+                        repo_url=repo_url,
+                        repo_path=repo_path,
+                        project_root=version_dir,
+                    )
+                )
+            if versions:
+                discovered[slug] = versions
+        except Exception as exc:
+            # Any unexpected error for this repo -> show user & keep going
+            st.error(f"Could not load project from {raw_url}: {exc}")
+
+    return discovered

--- a/src/label_app/ui/components/auth.py
+++ b/src/label_app/ui/components/auth.py
@@ -48,6 +48,11 @@ def is_logged_in() -> bool:
     return st.session_state.get("user") is not None
 
 
+def log_out() -> None:
+    remove_cookie("session")
+    del st.session_state["user"]
+
+
 def sidebar_logout(label: str = "Logout") -> None:
     """Add a small *Logout* button to the sidebar (visible when logged‑in)."""
 
@@ -55,7 +60,4 @@ def sidebar_logout(label: str = "Logout") -> None:
     if not st.session_state.get("user"):
         return  # nothing to show
 
-    if st.sidebar.button(label, use_container_width=True):
-        remove_cookie("session")
-        del st.session_state["user"]
-        st.rerun()
+    st.sidebar.button(label, use_container_width=True, on_click=log_out)

--- a/src/label_app/ui/components/version_selection.py
+++ b/src/label_app/ui/components/version_selection.py
@@ -1,0 +1,20 @@
+import json
+
+import streamlit as st
+
+from label_app.ui.components.cookies import get_cookie, put_cookie
+
+
+def sync_cookie() -> None:
+    if "version_selection" in st.session_state:
+        selection_json = json.dumps(st.session_state.version_selection)
+        put_cookie("version_selection", selection_json)
+    else:
+        selection_json = get_cookie("version_selection")
+        if selection_json is not None:
+            st.session_state.version_selection = json.loads(selection_json)
+
+
+def get_version_selection() -> dict[str, str] | None:
+    sync_cookie()
+    return st.session_state.get("version_selection")

--- a/src/label_app/ui/main.py
+++ b/src/label_app/ui/main.py
@@ -10,10 +10,19 @@ st.set_page_config(page_title="Text Labelling App", page_icon=str(ICON_PATH), la
 
 if is_logged_in():
     VISIBLE_PAGES = [
-        st.Page("page/02_project_select.py", title="Projects", icon="📂", default=True),
-        st.Page("page/03_annotate.py", title="Annotate", icon="✏️"),
+        st.Page(
+            "page/02_project_select.py",
+            title="Projects",
+            icon=":material/folder_open:",
+            default=True
+        ),
+        st.Page(
+            "page/03_annotate.py",
+            title="Annotate",
+            icon=":material/edit:"
+        ),
     ]
-    router = st.navigation(VISIBLE_PAGES, position="sidebar", expanded=False)
+    router = st.navigation(VISIBLE_PAGES, position="sidebar", expanded=True)
 else:
     VISIBLE_PAGES = [
         st.Page("page/01_login.py", title="Login", default=True),

--- a/src/label_app/ui/page/01_login.py
+++ b/src/label_app/ui/page/01_login.py
@@ -65,6 +65,7 @@ with st.container(border=True):
     with st.form(key="key_login", clear_on_submit=False, border=True, enter_to_submit=False):
         access_key = st.text_input(
             "Access key",
+            key="access_key_as_password",
             type="password",
             help=f"Ask the administrator for your key: {get_settings().admin_email}",
         )

--- a/src/label_app/ui/page/02_project_select.py
+++ b/src/label_app/ui/page/02_project_select.py
@@ -1,40 +1,80 @@
 import streamlit as st
 
-from label_app.config.settings import get_settings
+from label_app.data.models import Project
 from label_app.services.projects import discover_projects
-from label_app.ui.components.auth import require_login, sidebar_logout
+from label_app.services.git_client import clone_or_pull
+from label_app.ui.components.auth import sidebar_logout
+from label_app.ui.components.version_selection import get_version_selection
 
-require_login()
 
-st.header("Project Selection")
+@st.fragment()
+def display_project(slug: str, versions: list[Project]):
+    selected_version = st.session_state.version_selection[slug]
+    version_names = sorted(p.version for p in versions)
+    selected_idx = version_names.index(selected_version)
 
-sidebar_logout()
-search = st.sidebar.text_input("Search")
+    project = versions[selected_idx]
 
-projects = discover_projects(get_settings())
+    with st.container(border=True):
+        col_data, col_actions = st.columns([3, 1])
+        with col_data:
+            is_latest = selected_idx == len(versions) - 1
+            st.markdown(f"##### {project.name}"
+                        + (" :red-badge[latest]" if is_latest else "")
+                        + f" :blue-badge[{project.task_type}]"
+        )
+            if project.description:
+                st.markdown(project.description)
 
-with st.scrollable_container():
-    for slug, versions in projects.items():
-        version_names = sorted(p.version for p in versions)
-        default_idx = len(version_names) - 1
-
-        meta = versions[default_idx]
-        if search and search.lower() not in meta.name.lower():
-            continue
-
-        with st.container():
-            st.markdown(f"### {meta.name}")
-            if meta.description:
-                st.markdown(meta.description)
-
+        with col_actions:
             chosen_version = st.selectbox(
                 "Version",
                 version_names,
-                index=default_idx,
+                index=selected_idx,
                 key=f"ver_{slug}",
             )
+            chosen_idx = version_names.index(chosen_version)
+            if chosen_idx != selected_idx:
+                # selected version changed, need to redraw
+                st.session_state.version_selection[slug] = chosen_version
+                st.rerun(scope="fragment")
 
-            if st.button("Select", key=f"btn_{slug}"):
-                selected = next(p for p in versions if p.version == chosen_version)
-                st.session_state.selected_project = selected
+            selected_project = next(p for p in versions if p.version == chosen_version)
+            is_current_selected = "selected_project" in st.session_state \
+                                  and (st.session_state.selected_project == selected_project)
+
+            if st.button(
+                "Select" if not is_current_selected else "Selected",
+                key=f"btn_{slug}",
+                disabled=is_current_selected,
+                use_container_width=True,
+                type="primary"
+            ):
+                st.session_state.selected_project = selected_project
                 st.switch_page("page/03_annotate.py")
+
+
+header_col, refresh_col = st.columns([10, 1], vertical_alignment="bottom")
+with header_col:
+    st.header("Project Selection")
+with refresh_col:
+    if st.button("", icon=":material/refresh:", help="Refresh projects"):
+        discover_projects.clear()
+        clone_or_pull.clear()
+
+projects_holder = st.empty()
+
+sidebar_logout()
+
+projects = discover_projects()
+
+version_selection = get_version_selection() or {
+    slug: sorted(p.version for p in versions)[len(versions) - 1]
+    for slug, versions in projects.items()
+}
+st.session_state.version_selection = version_selection
+
+with projects_holder:
+    with st.container():
+        for slug, versions in projects.items():
+            display_project(slug, versions)

--- a/src/label_app/ui/page/02_project_select.py
+++ b/src/label_app/ui/page/02_project_select.py
@@ -1,8 +1,40 @@
 import streamlit as st
 
-from label_app.ui.components.auth import sidebar_logout
+from label_app.config.settings import get_settings
+from label_app.services.projects import discover_projects
+from label_app.ui.components.auth import require_login, sidebar_logout
+
+require_login()
 
 st.header("Project Selection")
-st.write("Select a project to start annotating.")
 
 sidebar_logout()
+search = st.sidebar.text_input("Search")
+
+projects = discover_projects(get_settings())
+
+with st.scrollable_container():
+    for slug, versions in projects.items():
+        version_names = sorted(p.version for p in versions)
+        default_idx = len(version_names) - 1
+
+        meta = versions[default_idx]
+        if search and search.lower() not in meta.name.lower():
+            continue
+
+        with st.container():
+            st.markdown(f"### {meta.name}")
+            if meta.description:
+                st.markdown(meta.description)
+
+            chosen_version = st.selectbox(
+                "Version",
+                version_names,
+                index=default_idx,
+                key=f"ver_{slug}",
+            )
+
+            if st.button("Select", key=f"btn_{slug}"):
+                selected = next(p for p in versions if p.version == chosen_version)
+                st.session_state.selected_project = selected
+                st.switch_page("page/03_annotate.py")


### PR DESCRIPTION
## Summary
- implement `git_client` and `projects` services for cloning repos and reading `project.yaml`
- add `Project` data model
- create real project selection page UI
- depend on GitPython
- document the change in AGENTS history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf9178e888331b018f75720d4a533